### PR TITLE
Board orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,17 @@ Head Tracker that runs on [Arduino Nano 33 BLE](https://store.arduino.cc/arduino
 
 **Arduino Nano 33 BLE** board if perfect for head tracker project, since it has both **9DOF IMU** for orientation and **Bluetooth** for connectivity.
 
-Before you begin, install special versions of Bluetooth and IMU libraries (see below).
+Before you begin, install special versions of Bluetooth, IMU and Madgwick libraries ([see below](#dependencies)).
 
-Upload `main` sketch, pair with radio, configure **TR1**, **TR2** and **TR3** inputs to be sent to your model for **pan**, **tilt** and **roll** servos.
+Next important step is IMU calibration ([see below](#calibration)).
 
-Good idea is to assign an override switch for pan and tilt channels, so you can always center your camera if something goes wrong with the head tracker. This is also convenient when you about to put your goggles on and do not want camera servos going mad.
+Upload `main` sketch, pair with radio, configure **TR1**, **TR2** and **TR3** as inputs for camera control servos.
 
-Default maximum angles: **45deg** each side, can be adjusted if your servos capable of more.
+Board orientation defines what trainer channels correspond to pan, tilt and roll of the camera.
 
-Do not forget to calibrate magnetometer.
+Assign an override switch for camera control channels, so you can always center your camera if needed.
+
+Default maximum angles: **45deg** each side, can be adjusted in `config.h` if your servos capable of more.
 
 ## Tested radios
 - FrSky X-Lite Pro (OpenTX version 2.3.11)

--- a/main/config.h
+++ b/main/config.h
@@ -35,6 +35,8 @@ const uint8_t ChannelPan  = 0;
 const uint8_t ChannelTilt = 1;
 const uint8_t ChannelRoll = 2;
 
+const uint8_t BoardTilt = 0;
+const uint8_t BoardRoll = 90;
 
 // -- Knobs to turn if you really know what you are doing ---
 

--- a/main/config.h
+++ b/main/config.h
@@ -31,12 +31,9 @@ const float_t imuCalibration[6][3] = {
 const uint8_t AngleMax = 45;
 
 // Trainer channels Head Tracker sends data
-const uint8_t ChannelPan  = 0;
-const uint8_t ChannelTilt = 1;
-const uint8_t ChannelRoll = 2;
-
-const uint8_t BoardTilt = 0;
-const uint8_t BoardRoll = 90;
+const uint8_t ChannelPitch = 0;
+const uint8_t ChannelRoll = 1;
+const uint8_t ChannelYaw = 2;
 
 // -- Knobs to turn if you really know what you are doing ---
 

--- a/main/imu.cpp
+++ b/main/imu.cpp
@@ -50,13 +50,29 @@ void imuUpdate() {
 }
 
 float_t imuPan() {
-  return FUSION.getYaw();
+  return FUSION.getYaw(); //[0, 360]
 }
 
 float_t imuTilt() {
-  return FUSION.getPitch();
+  float_t tilt = FUSION.getPitch(); // [-180, 180]
+  tilt += BoardTilt;
+  if (tilt < -180) {
+    tilt += 360;
+  }
+  if (tilt > 180) {
+    tilt -= 360;
+  }
+  return tilt;
 }
 
 float_t imuRoll() {
-  return FUSION.getRoll();
+  float_t roll = FUSION.getRoll(); // [-180, 180]
+  roll += BoardRoll;
+  if (roll < -180) {
+    roll += 360;
+  }
+  if (roll > 180) {
+    roll -= 360;
+  }
+  return roll;
 }

--- a/main/imu.h
+++ b/main/imu.h
@@ -7,8 +7,13 @@
 #include "utils.h"
 
 void imuSetup();
+void imuBegin();
 void imuUpdate();
 
-float_t imuPan();
-float_t imuTilt();
+float_t imuPitch();
 float_t imuRoll();
+float_t imuYaw();
+
+float_t imuStartPitch();
+float_t imuStartRoll();
+float_t imuStartYaw();

--- a/main/para.cpp
+++ b/main/para.cpp
@@ -27,6 +27,7 @@ uint8_t m_data[3] = { 0x41, 0x70, 0x70 };
 uint8_t ieee_data[14] = { 0xFE, 0x00, 0x65, 0x78, 0x70, 0x65, 0x72, 0x69, 0x6D, 0x65, 0x6E, 0x74, 0x61, 0x6C };
 uint8_t pnpid_data[7] = { 0x01, 0x0D, 0x00, 0x00, 0x00, 0x10, 0x01 };
 
+uint16_t channels[8] = { 1500, 1500, 1500, 1500, 1500, 1500, 1500, 1500 };
 
 void paraSetup() {
 
@@ -65,6 +66,10 @@ void paraSetup() {
 
 }
 
+void paraSet(uint8_t channel, uint16_t value) {
+  channels[channel] = value;
+}
+
 const uint8_t START_STOP = 0x7E;
 const uint8_t BYTE_STUFF = 0x7D;
 const uint8_t STUFF_MASK = 0x20;
@@ -80,7 +85,7 @@ void paraPushByte(uint8_t byte, uint8_t* buffer, uint8_t& bufferIndex, uint8_t& 
 }
 
 // Encodes channels array to para trainer packet (adapted from OpenTX source code)
-void paraSend(const uint16_t channels[8]) {
+void paraSend() {
 
   uint8_t buffer[32];
   uint8_t bufferIndex = 0;

--- a/main/para.h
+++ b/main/para.h
@@ -3,4 +3,5 @@
 #include <ArduinoBLE.h>
 
 void paraSetup();
-void paraSend(const uint16_t channels[8]);
+void paraSet(uint8_t channel, uint16_t value);
+void paraSend();


### PR DESCRIPTION
This change de-couples camera pan, tilt and roll angles from board pitch, roll and yaw angles.

Since the board can be attached quite differently on user's goggles/strap, different board rotation axes would correspond to different camera rotation axes. From now, the board will simply transmit its orientation via trainer channels, and user have to map them accordingly to camera servo channels.

Also
- min and max channel values were adjusted to be 988 and 2012 (was 1000 and 2000);
- minor refactoring