### PR TITLE
Xiao BLE: High charge current

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,3 +39,10 @@ jobs:
 
     - name: Build Nano 33 BLE binary
       run: make TARGET=nano-33-ble-s140v6-uf2 build
+
+    - name: Store binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: binaries
+        path: build/*
+        retention-days: 14

--- a/src/extras_nano-33-ble.go
+++ b/src/extras_nano-33-ble.go
@@ -1,0 +1,7 @@
+//go:build nano_33_ble
+
+package main
+
+func initExtras() {
+	// nop
+}

--- a/src/extras_xiao-ble.go
+++ b/src/extras_xiao-ble.go
@@ -1,0 +1,23 @@
+//go:build xiao_ble
+
+// The battery charging current is selectable as 50mA or 100mA,
+// where you can set Pin13 as high or low to change it to 50mA or 100mA.
+//
+// The low current charging current is at the input model set up as HIGH LEVEL
+// and the high current charging current is at the output model set up as LOW LEVEL.
+//
+// In this project, we ensure the high current charging is enabled by default.
+//
+// See https://wiki.seeedstudio.com/XIAO_BLE/#battery-charging-current
+package main
+
+import "machine"
+
+var (
+	pinChargeCurrent = machine.P0_13
+)
+
+func initExtras() {
+	pinChargeCurrent.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	pinChargeCurrent.Low() // enable charging at high current, 100mA
+}

--- a/src/main.go
+++ b/src/main.go
@@ -35,6 +35,7 @@ func init() {
 
 	initLeds()
 	initPins()
+	initExtras()
 
 	// Orientation
 	o = orientation.New()


### PR DESCRIPTION
Ensures 100mA charge current is enabled on Xiao BLE boards.

Fixes #32 