### PR TITLE
Store calibration to flash memory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ else
 FILE = ht_nano-33-ble_$(VERSION).uf2
 endif
 
-.PHONY: clean build flash
+.PHONY: clean build flash monitor
 
 # --- Common targets ---
 
@@ -23,6 +23,9 @@ build:
 
 flash:
 	tinygo flash $(LD_FLAGS) -target=$(TARGET) -size=$(SIZE) -opt=z -print-allocs=main ./src
+
+monitor:
+	tinygo monitor -target=$(TARGET)
 
 # --- Arduino Nano 33 BLE bootloader targets ---
 

--- a/src/flash.go
+++ b/src/flash.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"errors"
+	"machine"
+)
+
+var errFlashWrongChecksum = errors.New("wrong checksum reading data from flash")
+
+type Flash struct {
+	roll, pitch, yaw int32
+}
+
+func (fd *Flash) IsEmpty() bool {
+	return fd.roll == 0 && fd.pitch == 0 && fd.yaw == 0
+}
+
+func (fd *Flash) Load() error {
+
+	data := make([]byte, 3*4+1) // each calibration parameter is int32, plus checksum
+	_, err := machine.Flash.ReadAt(data, 0)
+	if err != nil {
+		return err
+	}
+
+	// xor all bytes, including the last checksum byte
+	checksum := byte(0)
+	for _, b := range data {
+		checksum ^= b
+	}
+	if checksum != 0 {
+		return errFlashWrongChecksum
+	}
+
+	fd.roll = toInt32(data[0:4])
+	fd.pitch = toInt32(data[4:8])
+	fd.yaw = toInt32(data[8:12])
+
+	return nil
+}
+
+func (fd *Flash) Store() error {
+	data := make([]byte, 3*4+1) // each calibration parameter is int32, plus checksum
+	fromInt32(data[0:4], fd.roll)
+	fromInt32(data[4:8], fd.pitch)
+	fromInt32(data[8:12], fd.yaw)
+
+	// xor all bytes, including the last (it is zero anyway)
+	checksum := byte(0)
+	for _, b := range data {
+		checksum ^= b
+	}
+	data[12] = checksum
+
+	err := machine.Flash.EraseBlocks(0, 1)
+	if err != nil {
+		return err
+	}
+	_, err = machine.Flash.WriteAt(data, 0)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func toInt32(b []byte) int32 {
+	return int32(b[0]) | int32(b[1])<<8 | int32(b[2])<<16 | int32(b[3])<<24
+}
+
+func fromInt32(b []byte, v int32) {
+	b[0] = byte(v)
+	b[1] = byte(v >> 8)
+	b[2] = byte(v >> 16)
+	b[3] = byte(v >> 24)
+}

--- a/src/orientation/gyrcal.go
+++ b/src/orientation/gyrcal.go
@@ -28,7 +28,7 @@ const (
 	gyrCalBatchSize           = 1000                 // 1 sec on warm-up, 20 sec during regular operation
 	gyrCalBatchEscapeMax      = gyrCalBatchSize / 10 // tolerate 10% values outside threshold
 	gyrCalForceAdjustment     = 10                   // first 10 batches applied always, regardles of number of escapes
-	gyrCalValueThreshold      = 3_000_000            // this is hardware center point precision (we can expect values in this range when stationary)
+	gyrCalValueThreshold      = 4_000_000            // this is hardware center point precision (we can expect values in this range when stationary)
 	gyrCalCorrectionThreshold = 100_000              // shall be good enough to eliminate axis drift while keeping time of warm-up low
 )
 

--- a/src/orientation/gyrcal.go
+++ b/src/orientation/gyrcal.go
@@ -81,7 +81,9 @@ func (g *GyrCal) adjustAxisOffset(i int32) {
 	if g.countEscape[i] < gyrCalBatchEscapeMax || g.countAdjust[i] < gyrCalForceAdjustment {
 		g.correctionLast[i] = g.correctionSum[i] / 2 // be careful and half-step
 		g.Offset[i] += g.correctionLast[i]
+		if g.countAdjust[i] < gyrCalForceAdjustment {
 			g.countAdjust[i]++
+		}
 	}
 	g.correctionSum[i] = 0
 	g.countApply[i] = 0

--- a/src/orientation/orientation.go
+++ b/src/orientation/orientation.go
@@ -73,11 +73,6 @@ func (o *Orientation) Update() {
 	o.current.V = mgl.Vec3{q[1], q[2], q[3]}
 }
 
-// Stable state indicates gyroscope calibration is good
-func (o *Orientation) Stable() bool {
-	return o.imu.gyrCal.Stable
-}
-
 // Angles in radians
 func (o *Orientation) Angles() (angles [3]float64) {
 	q := o.current
@@ -87,6 +82,28 @@ func (o *Orientation) Angles() (angles [3]float64) {
 	return
 }
 
+// Stable state indicates gyroscope calibration is good
+func (o *Orientation) Stable() bool {
+	return o.imu.gyrCal.Stable
+}
+
+func (o *Orientation) SetStable(stable bool) {
+	o.imu.gyrCal.Stable = stable
+}
+
 func (o *Orientation) Offsets() (roll, pitch, yaw int32) {
 	return o.imu.gyrCal.Offset[0], o.imu.gyrCal.Offset[1], o.imu.gyrCal.Offset[2]
+}
+
+func (o *Orientation) SetOffsets(roll, pitch, yaw int32) {
+	o.imu.gyrCal.Offset[0] = roll
+	o.imu.gyrCal.Offset[1] = pitch
+	o.imu.gyrCal.Offset[2] = yaw
+	if roll == 0 && pitch == 0 && yaw == 0 {
+		return
+	}
+	// calibration shall skip aggressive first force adjustments when data is non-zero
+	o.imu.gyrCal.countAdjust[0] = gyrCalForceAdjustment + 1
+	o.imu.gyrCal.countAdjust[1] = gyrCalForceAdjustment + 1
+	o.imu.gyrCal.countAdjust[2] = gyrCalForceAdjustment + 1
 }


### PR DESCRIPTION
This enables startups be fast, since they do not require calibration.

The very first power up does require calibration from scratch.
Every subsequent power up shall improve already good initial calibration. Improvements accumulate.

The stored calibration is discarded when reset button is pressed (connected to GND) on power up.
The initial calibration process then starts anew and the result is stored to flash.

The stored calibration data can be lost when a new firmware version is flashed on device.

Also adjusted some parameters, fixed couple overflows and documented the calibration procedure.