### PR TITLE
Improve sensor fusion processing

### DIFF
--- a/src/orientation/imu_xiao-ble.go
+++ b/src/orientation/imu_xiao-ble.go
@@ -44,9 +44,9 @@ func (imu *IMU) Configure() {
 	imu.device = lsm6ds3tr.New(machine.I2C1)
 	imu.device.Configure(lsm6ds3tr.Configuration{
 		AccelRange:      lsm6ds3tr.ACCEL_4G,     // 4g
-		AccelSampleRate: lsm6ds3tr.ACCEL_SR_833, // every ~1.2ms
+		AccelSampleRate: lsm6ds3tr.ACCEL_SR_104, // every ~9.6ms
 		GyroRange:       lsm6ds3tr.GYRO_500DPS,  // 500 deg/s
-		GyroSampleRate:  lsm6ds3tr.GYRO_SR_833,  // every ~1.2ms
+		GyroSampleRate:  lsm6ds3tr.GYRO_SR_104,  // every ~9.6ms
 	})
 
 	tapConfig := map[byte]byte{

--- a/src/orientation/orientation.go
+++ b/src/orientation/orientation.go
@@ -11,6 +11,10 @@ import (
 const radToDeg = 180 / math.Pi // 57.29578
 const degToRad = 1 / radToDeg  // 0.0174533
 
+// Rule of thumb: increasing beta leads to (a) faster bias corrections, (b) higher sensitiveness to lateral accelerations.
+// https://stackoverflow.com/questions/47589230/what-is-the-best-beta-value-in-madgwick-filter
+const madgwickBeta = 0.025
+
 type Orientation struct {
 	imu     *IMU
 	fusion  ahrs.Madgwick
@@ -27,7 +31,7 @@ func New(imu *IMU) *Orientation {
 
 func (o *Orientation) Configure(period time.Duration) {
 	o.imu.Configure()
-	o.fusion = ahrs.NewMadgwick(0.025, float64(time.Second/period))
+	o.fusion = ahrs.NewMadgwick(madgwickBeta, float64(time.Second/period))
 }
 
 // Reset orientation for sensor fusion algoritm


### PR DESCRIPTION
- Use 10ms `time.Ticker` in main loop  -- instead of 20ms `time.Sleep`
- Adjust IMU sample rate to be 104Hz -- roughly matches main loop ticker
- Collect garbage often -- to avoid long unpredicted pauses.

This all makes sensor fusion algorithm work much better.