### PR TITLE
fix: stable period in main loop + debug pins

### DIFF
--- a/src/display/display.go
+++ b/src/display/display.go
@@ -3,7 +3,6 @@ package display
 import (
 	"image/color"
 	"machine"
-	"time"
 
 	"tinygo.org/x/drivers/ssd1306"
 	"tinygo.org/x/tinydraw"
@@ -119,13 +118,10 @@ func (d *Display) SetBar(row byte, value int16, bidir bool) {
 	d.Bars[row].bidir = bidir
 }
 
-func (d *Display) Run() {
-	for {
-		d.bars()
-		d.blink()
-		d.device.Display()
-		time.Sleep(100 * time.Millisecond)
-	}
+func (d *Display) Update() {
+	d.bars()
+	d.blink()
+	d.device.Display()
 }
 
 func (d *Display) bars() {

--- a/src/main.go
+++ b/src/main.go
@@ -76,6 +76,7 @@ func main() {
 	}
 	d.AddText(0, "Head Tracker "+batString)
 	d.AddText(1, Version+" @ysoldak")
+	d.Update()
 
 	// warm up IMU (1 sec)
 	for i := 0; i < 50; i++ {
@@ -95,10 +96,12 @@ func main() {
 	}
 	d.RemoveText(nil)
 	d.SetTextBlink(d.AddText(1, waitText+"   "), waitText+"...", true)
+	d.Update()
 	prev := [3]int32{0, 0, 0}
 	directions := [3]int32{1, 1, 1}
 	maxCorrection := int32(2_000_000)
 	iter := uint16(0)
+	stopTime := time.Now().Add(3 * time.Second)
 	for {
 
 		for i, v := range o.Calibrate() {
@@ -127,7 +130,11 @@ func main() {
 		iter++
 		iter %= 10_000
 
-		if iter > 3000 && !f.IsEmpty() { // when had some calibration already, force it if was not able to find better quickly
+		if iter%10 == 0 {
+			d.Update()
+		}
+
+		if time.Now().After(stopTime) && !f.IsEmpty() { // when had some calibration already, force it if was not able to find better quickly
 			o.SetOffsets(f.roll, f.pitch, f.yaw)
 			o.SetStable(true)
 		}
@@ -152,6 +159,7 @@ func main() {
 	if pinSelectPPM.Get() { // high means Bluetooth
 		d.SetTextBlinkFunc(d.AddText(1, "  :  :  :  :  :  "), "", func() bool { return !t.Paired() })
 	}
+	d.Update()
 
 	// main loop
 	iter = 0

--- a/src/pins.go
+++ b/src/pins.go
@@ -3,12 +3,16 @@ package main
 import "machine"
 
 var (
+	pinDebugMain   = machine.D0
+	pinDebugData   = machine.D1
 	pinResetCenter = machine.D2
 	pinSelectPPM   = machine.D8
 	pinOutputPPM   = machine.D10
 )
 
 func initPins() {
+	pinDebugMain.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	pinDebugData.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	pinResetCenter.Configure(machine.PinConfig{Mode: machine.PinInputPullup})
 	pinSelectPPM.Configure(machine.PinConfig{Mode: machine.PinInputPullup})
 	pinOutputPPM.Configure(machine.PinConfig{Mode: machine.PinOutput})

--- a/src/pins.go
+++ b/src/pins.go
@@ -3,8 +3,8 @@ package main
 import "machine"
 
 var (
-	pinDebugMain   = machine.D0
-	pinDebugData   = machine.D1
+	pinDebugMain   = machine.P0_02
+	pinDebugData   = machine.P0_03
 	pinResetCenter = machine.D2
 	pinSelectPPM   = machine.D8
 	pinOutputPPM   = machine.D10

--- a/src/trainer/ppm.go
+++ b/src/trainer/ppm.go
@@ -58,8 +58,12 @@ func (ppm *PPM) Configure() {
 	configurePpi()
 }
 
-func (ppm *PPM) Run() {
+func (ppm *PPM) Start() {
 	ppmTimerLow.TASKS_START.Set(1)
+}
+
+func (ppm *PPM) Update() {
+	// no-op
 }
 
 func (ppm *PPM) Paired() bool {

--- a/src/trainer/trainer.go
+++ b/src/trainer/trainer.go
@@ -2,7 +2,8 @@ package trainer
 
 type Trainer interface {
 	Configure()
-	Run()
+	Start()
+	Update()
 	Paired() bool
 	Address() string
 	Channels() []uint16


### PR DESCRIPTION
This refactors code to achieve stable predictable main loop period -- important for sensor fusion algorithm.
Measured and confirmed with help of debug pins (`D0` and `D1`).

Previously, main loop, display and bluetooth (para) update tasks run in separate go routines with own periods.
Such design requires frequent context switching by runtime and results in unpredictable delays that make tickers unreliable in cooperative multitasking scenario.

Now, the main loop runs and updates display and trainer periodically (every second cycle, i.e. every 20ms). Other times the main loop triggers garbage collection to keep heap clean and avoid long garbage collections at unpredictable moments.