### PR TITLE
fix: handle IMU configuration errors

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -48,7 +48,13 @@ func init() {
 	// Orientation
 	i = orientation.NewIMU()
 	o = orientation.New(i)
-	o.Configure(PERIOD * time.Millisecond)
+	err := o.Configure(PERIOD * time.Millisecond)
+	if err != nil {
+		for {
+			println("IMU configuration error:", err.Error())
+			time.Sleep(1 * time.Second)
+		}
+	}
 
 	// Trainer (Bluetooth or PPM)
 	if !pinSelectPPM.Get() { // Low means connected to GND => PPM output requested

--- a/src/orientation/imu_nano-33-ble.go
+++ b/src/orientation/imu_nano-33-ble.go
@@ -20,20 +20,23 @@ func NewIMU() *IMU {
 	}
 }
 
-func (imu *IMU) Configure() {
+func (imu *IMU) Configure() error {
 	// Configure I2C
-	machine.I2C1.Configure(machine.I2CConfig{
+	err := machine.I2C1.Configure(machine.I2CConfig{
 		Frequency: 100 * machine.KHz,
 		SDA:       machine.SDA1_PIN,
 		SCL:       machine.SCL1_PIN,
 	})
+	if err != nil {
+		return err
+	}
 
 	// Wait a bit
 	time.Sleep(10 * time.Millisecond)
 
 	// Configure IMU
 	imu.device = lsm9ds1.New(machine.I2C1)
-	imu.device.Configure(lsm9ds1.Configuration{
+	err = imu.device.Configure(lsm9ds1.Configuration{
 		AccelRange:      lsm9ds1.ACCEL_4G,
 		AccelSampleRate: lsm9ds1.ACCEL_SR_238,
 		GyroRange:       lsm9ds1.GYRO_500DPS,
@@ -42,6 +45,7 @@ func (imu *IMU) Configure() {
 		MagSampleRate:   lsm9ds1.MAG_SR_80,
 	})
 
+	return err
 }
 
 func (imu *IMU) Read() (gx, gy, gz, ax, ay, az float64, err error) {

--- a/src/orientation/imu_xiao-ble.go
+++ b/src/orientation/imu_xiao-ble.go
@@ -30,25 +30,31 @@ func NewIMU() *IMU {
 	}
 }
 
-func (imu *IMU) Configure() {
+func (imu *IMU) Configure() error {
 	// Configure I2C
-	machine.I2C1.Configure(machine.I2CConfig{
+	err := machine.I2C1.Configure(machine.I2CConfig{
 		Frequency: 100 * machine.KHz,
 		SDA:       machine.SDA1_PIN,
 		SCL:       machine.SCL1_PIN,
 	})
+	if err != nil {
+		return err
+	}
 
 	// Wait a bit
 	time.Sleep(10 * time.Millisecond)
 
 	// Configure IMU
 	imu.device = lsm6ds3tr.New(machine.I2C1)
-	imu.device.Configure(lsm6ds3tr.Configuration{
+	err = imu.device.Configure(lsm6ds3tr.Configuration{
 		AccelRange:      lsm6ds3tr.ACCEL_4G,     // 4g
 		AccelSampleRate: lsm6ds3tr.ACCEL_SR_208, // every ~4.8ms
 		GyroRange:       lsm6ds3tr.GYRO_500DPS,  // 500 deg/s
 		GyroSampleRate:  lsm6ds3tr.GYRO_SR_208,  // every ~4.8ms
 	})
+	if err != nil {
+		return err
+	}
 
 	tapConfig := map[byte]byte{
 		TAP_CFG:     0x8F, // interrupts enable + tap all axes + latch (saves the state of the interrupt until register is read)
@@ -62,6 +68,7 @@ func (imu *IMU) Configure() {
 		machine.I2C1.WriteRegister(uint8(imu.device.Address), reg, []byte{val})
 	}
 
+	return nil
 }
 
 func (imu *IMU) Read() (gx, gy, gz, ax, ay, az float64, err error) {

--- a/src/orientation/orientation.go
+++ b/src/orientation/orientation.go
@@ -29,9 +29,13 @@ func New(imu *IMU) *Orientation {
 	}
 }
 
-func (o *Orientation) Configure(period time.Duration) {
-	o.imu.Configure()
+func (o *Orientation) Configure(period time.Duration) error {
+	err := o.imu.Configure()
+	if err != nil {
+		return err
+	}
 	o.fusion = ahrs.NewMadgwick(madgwickBeta, float64(time.Second/period))
+	return nil
 }
 
 // Reset orientation for sensor fusion algoritm


### PR DESCRIPTION
Shall help in cases when people flash firmware to a wrong board: 
- `XIAO BLE` instead of `XIAO BLE Sense` -- no IMU
- `Nano 33 BLE Rev2` instead of `Nano 33 BLE [Rev1]` -- different IMU