### PR TITLE
feat: Control and Configure HT over BT

### DIFF
--- a/src/main_sys.go
+++ b/src/main_sys.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"machine"
+	"time"
+)
+
+// implements trainer.SystemHandler interface
+type SystemHandler struct {
+	name           string
+	channelsConfig [3]byte // offset, order, enabled
+}
+
+func NewSystemHandler() *SystemHandler {
+	return &SystemHandler{
+		name: "HT",
+	}
+}
+
+func (sh *SystemHandler) OrientationReset() {
+	println("MAIN: Orientation reset")
+	o.Reset() // FIXME: also blink red led
+}
+
+func (sh *SystemHandler) FactoryReset() {
+	println("MAIN: Factory reset requested, resetting flash data and restarting...")
+	f = NewFlash() // reset flash object
+	f.Store()      // store empty object
+	time.Sleep(1 * time.Second)
+	machine.CPUReset() // restart device
+}
+
+func (sh *SystemHandler) Reboot() {
+	println("MAIN: Reboot requested, restarting...")
+	time.Sleep(1 * time.Second)
+	machine.CPUReset()
+}
+
+func (sh *SystemHandler) Name() string {
+	return sh.name
+}
+
+func (sh *SystemHandler) SetName(newName string) {
+	if newName != sh.name {
+		println("FLASH: Device name write:", newName)
+		sh.name = newName
+		f.SetName(newName)
+		err := f.Store()
+		if err != nil {
+			println("FLASH: store error:", err.Error())
+		}
+	}
+}
+
+func (sh *SystemHandler) ChannelsConfig() (byte, byte, byte) {
+	return sh.channelsConfig[0], sh.channelsConfig[1], sh.channelsConfig[2]
+}
+
+func (sh *SystemHandler) SetChannelsConfig(offset byte, order byte, enabled byte) {
+	println("FLASH: Channels configuration write: offset =", offset, " order =", order, " enabled =", enabled)
+	sh.channelsConfig[0] = offset
+	sh.channelsConfig[1] = order
+	sh.channelsConfig[2] = enabled
+	f.channels[0] = offset
+	f.channels[1] = order
+	f.channels[2] = enabled
+	err := f.Store()
+	if err != nil {
+		println("FLASH: store error:", err.Error())
+	}
+}

--- a/src/orientation/orientation.go
+++ b/src/orientation/orientation.go
@@ -100,15 +100,13 @@ func (o *Orientation) SetStable(stable bool) {
 	o.imu.gyrCal.Stable = stable
 }
 
-func (o *Orientation) Offsets() (roll, pitch, yaw int32) {
-	return o.imu.gyrCal.Offset[0], o.imu.gyrCal.Offset[1], o.imu.gyrCal.Offset[2]
+func (o *Orientation) Offsets() (offsets [3]int32) {
+	return o.imu.gyrCal.Offset
 }
 
-func (o *Orientation) SetOffsets(roll, pitch, yaw int32) {
-	o.imu.gyrCal.Offset[0] = roll
-	o.imu.gyrCal.Offset[1] = pitch
-	o.imu.gyrCal.Offset[2] = yaw
-	if roll == 0 && pitch == 0 && yaw == 0 {
+func (o *Orientation) SetOffsets(offsets [3]int32) {
+	o.imu.gyrCal.Offset = offsets
+	if offsets[0] == 0 && offsets[1] == 0 && offsets[2] == 0 {
 		return
 	}
 	// calibration shall skip aggressive first force adjustments when data is non-zero

--- a/src/trainer/ppm.go
+++ b/src/trainer/ppm.go
@@ -51,7 +51,7 @@ func NewPPM(pin machine.Pin) *PPM {
 	return &ppmInstance
 }
 
-func (ppm *PPM) Configure(_ string) {
+func (ppm *PPM) Configure() {
 	ppm.pin.Low()
 	configurePin()
 	configureTimers()
@@ -74,24 +74,8 @@ func (ppm *PPM) Address() string {
 	return "    PPM OUTPUT"
 }
 
-func (ppm *PPM) Channels() []uint16 {
-	return ppm.channels[:]
-}
-
 func (ppm *PPM) SetChannel(n int, v uint16) {
 	ppm.channels[n] = v
-}
-
-func (ppm *PPM) OrientationReset() bool {
-	return false
-}
-
-func (ppm *PPM) FactoryReset() bool {
-	return false
-}
-
-func (ppm *PPM) Name() (string, bool) {
-	return "", false
 }
 
 // --- Configure --------------------------------------------------------------

--- a/src/trainer/ppm.go
+++ b/src/trainer/ppm.go
@@ -39,7 +39,6 @@ var ppmTimerHigh *nrf.TIMER_Type = nrf.TIMER4
 var ppmInstance PPM
 
 type PPM struct {
-	name     string
 	pin      machine.Pin
 	channels [3]uint16
 }
@@ -52,8 +51,7 @@ func NewPPM(pin machine.Pin) *PPM {
 	return &ppmInstance
 }
 
-func (ppm *PPM) Configure(name string) {
-	ppm.name = name
+func (ppm *PPM) Configure(_ string) {
 	ppm.pin.Low()
 	configurePin()
 	configureTimers()
@@ -84,12 +82,16 @@ func (ppm *PPM) SetChannel(n int, v uint16) {
 	ppm.channels[n] = v
 }
 
-func (ppm *PPM) Reset() bool {
+func (ppm *PPM) OrientationReset() bool {
 	return false
 }
 
-func (ppm *PPM) Name() string {
-	return ppm.name
+func (ppm *PPM) FactoryReset() bool {
+	return false
+}
+
+func (ppm *PPM) Name() (string, bool) {
+	return "", false
 }
 
 // --- Configure --------------------------------------------------------------

--- a/src/trainer/ppm.go
+++ b/src/trainer/ppm.go
@@ -39,6 +39,7 @@ var ppmTimerHigh *nrf.TIMER_Type = nrf.TIMER4
 var ppmInstance PPM
 
 type PPM struct {
+	name     string
 	pin      machine.Pin
 	channels [3]uint16
 }
@@ -51,7 +52,8 @@ func NewPPM(pin machine.Pin) *PPM {
 	return &ppmInstance
 }
 
-func (ppm *PPM) Configure(_ string) {
+func (ppm *PPM) Configure(name string) {
+	ppm.name = name
 	ppm.pin.Low()
 	configurePin()
 	configureTimers()
@@ -82,8 +84,12 @@ func (ppm *PPM) SetChannel(n int, v uint16) {
 	ppm.channels[n] = v
 }
 
-func (ppm *PPM) ResetRequested() bool {
+func (ppm *PPM) Reset() bool {
 	return false
+}
+
+func (ppm *PPM) Name() string {
+	return ppm.name
 }
 
 // --- Configure --------------------------------------------------------------

--- a/src/trainer/trainer.go
+++ b/src/trainer/trainer.go
@@ -12,6 +12,7 @@ type Trainer interface {
 	Address() string
 
 	// Remote controls
-	Reset() bool
-	Name() string
+	OrientationReset() bool // whether an orientation reset was requested
+	FactoryReset() bool     // whether a factory reset was requested
+	Name() (string, bool)   // new name and whether it changed
 }

--- a/src/trainer/trainer.go
+++ b/src/trainer/trainer.go
@@ -10,5 +10,8 @@ type Trainer interface {
 	Update()
 	Paired() bool
 	Address() string
-	ResetRequested() bool
+
+	// Remote controls
+	Reset() bool
+	Name() string
 }

--- a/src/trainer/trainer.go
+++ b/src/trainer/trainer.go
@@ -1,18 +1,12 @@
 package trainer
 
 type Trainer interface {
-	Configure(name string)
+	Configure()
 	Start()
-	Channels() []uint16
 	SetChannel(num int, v uint16)
 
 	// Bluetooth specific
 	Update()
 	Paired() bool
 	Address() string
-
-	// Remote controls
-	OrientationReset() bool // whether an orientation reset was requested
-	FactoryReset() bool     // whether a factory reset was requested
-	Name() (string, bool)   // new name and whether it changed
 }


### PR DESCRIPTION
BT characteristics functions:
- Set device name by writing up to 16 characters to `0xFFD1` characteristic
- Set channels offset by writing [0:8) to `0xFFD2` characteristic
- Set channels order by writing [0:6) to `0xFFD3` characteristic
- Set channels enabled flags by writing [0:8) to `0xFFD4` characteristic
- Reset orientation by writing `'R'` to either `0xFFC1` or `0xAFF2` characteristic
- Factory reset board by writing `'F'` to either `0xFFC1` or `0xAFF2` characteristic
- Reboot board by writing `'B'` to either `0xFFC1` or `0xAFF2` characteristic

Channel order table:
```
0:	{1, 2, 3},
1:	{1, 3, 2},
2:	{2, 1, 3},
3:	{2, 3, 1},
4:	{3, 1, 2},
5:	{3, 2, 1},
```

Example channel config:
`offset: 6, order: 4, enabled: 5`
- axes in oder `3,1,2` (order: 4; see table above)
- axis 2 disabled (enabled: `0b00000101`; channel 1 bit is the rightmost, channel 3 bit is to the left)
- axes 3 and 1 moved to the end (offset: 6)
`[1500,1500,1500,1500,1500,1500,1232,1786]`

Under the hood: 
- Flash format redesigned to allow for future additions
- Build PRs against both latest TinyGo release and also against dev branch
- Dump gyro calibration offsets to flash in runtime, as TinyGo allows this now (dev branch only)

---
*NOTE: Binaries built against TinyGo 0.39.0 will not work, as released version does not support having SoftDevice (Bluetooth) active and write to flash the same time. Use `tinygo-dev:latest` binaries.*