### PR TITLE
para: set axis-to-channel mapping

### DIFF
--- a/src/callbacks.go
+++ b/src/callbacks.go
@@ -41,3 +41,8 @@ func (b *BluetoothCallbackHandler) OnDeviceNameChange(name string) {
 	println("Device name changed to", name)
 	state.deviceName = name
 }
+
+func (b *BluetoothCallbackHandler) OnAxisMappingChange(mapping [3]byte) {
+	println("Axis mapping changed to", mapping[0], mapping[1], mapping[2])
+	state.axisMapping = mapping
+}

--- a/src/callbacks.go
+++ b/src/callbacks.go
@@ -26,7 +26,7 @@ func (b *BluetoothCallbackHandler) OnOrientationReset() {
 func (b *BluetoothCallbackHandler) OnFactoryReset() {
 	println("Factory reset via Bluetooth command")
 	f = NewFlash() // reset flash object
-	f.Store()      // store default flash data
+	f.Save()       // save default flash data
 	time.Sleep(1 * time.Second)
 	machine.CPUReset()
 }

--- a/src/flash.go
+++ b/src/flash.go
@@ -41,6 +41,8 @@ func (fd *Flash) IsEmpty() bool {
 
 func (fd *Flash) Load() error {
 
+	println("Loading from flash")
+
 	data := make([]byte, FLASH_LENGTH)
 
 	_, err := machine.Flash.ReadAt(data[:], 0)
@@ -73,6 +75,7 @@ func (fd *Flash) Load() error {
 	for i := range FLASH_GYR_CAL_BLOCKS {
 		fd.gyrCalOffsets[i] = toInt32(data[offset+i*4 : offset+(i+1)*4])
 	}
+	println("  gyro calibration:", fd.gyrCalOffsets[0], fd.gyrCalOffsets[1], fd.gyrCalOffsets[2])
 	offset += FLASH_GYR_CAL_BYTES
 
 	// read device name, best effort
@@ -83,6 +86,7 @@ func (fd *Flash) Load() error {
 	for i := 0; i < FLASH_DEVICE_NAME_BYTES; i++ {
 		fd.deviceName[i] = data[offset+i]
 	}
+	println("  device name:", fd.DeviceName())
 	offset += FLASH_DEVICE_NAME_BYTES
 
 	// read axis mapping, best effort
@@ -93,17 +97,15 @@ func (fd *Flash) Load() error {
 	for i := 0; i < FLASH_AXIS_MAPPING_BYTES; i++ {
 		fd.axisMapping[i] = data[offset+i]
 	}
-	offset += FLASH_AXIS_MAPPING_BYTES
-
-	println("Loaded from flash")
-	println("  gyro calibration:", fd.gyrCalOffsets[0], fd.gyrCalOffsets[1], fd.gyrCalOffsets[2])
-	println("  device name:", fd.DeviceName())
 	println("  axis mapping:", fd.axisMapping[0], fd.axisMapping[1], fd.axisMapping[2])
+	offset += FLASH_AXIS_MAPPING_BYTES
 
 	return nil
 }
 
-func (fd *Flash) Store() error {
+func (fd *Flash) Save() error {
+
+	println("Saving to flash")
 
 	data := make([]byte, FLASH_LENGTH)
 
@@ -114,18 +116,21 @@ func (fd *Flash) Store() error {
 	for i := range FLASH_GYR_CAL_BLOCKS {
 		fromInt32(data[offset+i*4:offset+(i+1)*4], fd.gyrCalOffsets[i])
 	}
+	println("  gyro calibration:", fd.gyrCalOffsets[0], fd.gyrCalOffsets[1], fd.gyrCalOffsets[2])
 	offset += FLASH_GYR_CAL_BYTES
 
 	// device name
 	for i := 0; i < FLASH_DEVICE_NAME_BYTES; i++ {
 		data[offset+i] = fd.deviceName[i]
 	}
+	println("  device name:", fd.DeviceName())
 	offset += FLASH_DEVICE_NAME_BYTES
 
 	// axis mapping
 	for i := 0; i < FLASH_AXIS_MAPPING_BYTES; i++ {
 		data[offset+i] = fd.axisMapping[i]
 	}
+	println("  axis mapping:", fd.axisMapping[0], fd.axisMapping[1], fd.axisMapping[2])
 	offset += FLASH_AXIS_MAPPING_BYTES
 
 	// xor all bytes, but the first
@@ -144,10 +149,6 @@ func (fd *Flash) Store() error {
 		return err
 	}
 
-	println("Stored to flash")
-	println("  gyro calibration:", fd.gyrCalOffsets[0], fd.gyrCalOffsets[1], fd.gyrCalOffsets[2])
-	println("  device name:", fd.DeviceName())
-	println("  axis mapping:", fd.axisMapping[0], fd.axisMapping[1], fd.axisMapping[2])
 	return nil
 }
 


### PR DESCRIPTION
Set axes to channels mapping by writing 3 bytes to `0xFFD2` characteristic.
First (leftmost) byte configures mapping of the first axis to a channel, and so on. 

Each byte has format: `00IE0OOO`
- `0`   bit is not used,
- `I`   bit for inverted(1)/not inverted(0),
- `E`   bit for enabled(1)/disabled(0)
- `OOO` three bits for channel index offset (0-7),

Examples
- `0x10` means axis mapped to channel 1 (offset 0), enabled,  not inverted
- `0x11` means axis mapped to channel 2 (offset 1), enabled,  not inverted
- `0x25` means axis mapped to channel 6 (offset 5), disabled, inverted
- `0x34` means axis mapped to channel 5 (offset 4), enabled,  inverted

Default mapping: `0x101112` -- first 3 channels, enabled, not inverted
