### PR TITLE
para: send up to 16 channels

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -206,7 +206,7 @@ func main() {
 		for i, a := range o.Angles() {
 			state.channels[i] = angleToChannel(a)
 			d.SetBar(byte(i), int16(1500-state.channels[i])/10, false)
-			chIndex := state.axisMapping[i] & 0x07 // channel index
+			chIndex := state.axisMapping[i] & 0x0F // channel index
 			chValue := state.channels[i]
 			if state.axisMapping[i]&0x10 != 0x10 { // axis disabled
 				chValue = 1500


### PR DESCRIPTION
Configuring channel offset of an axis greater than `7` makes the HeadTracker pack and send `16` channels to master.

---

This however does not work yet, bluetooth library errors out with `invalid data size`.
That is because the default ATT_MTU size for BLE is 23 bytes, and the notification payload is limited to (ATT_MTU - 3) = 20 bytes.

Must negotiate a larger MTU with the client (using the ATT_MTU exchange procedure), otherwise the SoftDevice enforces this 20-byte limit for notifications and indications. Attempting to send more will result in an error like `NRF_ERROR_DATA_SIZE`.

To fix this, must call the MTU exchange function (e.g., `sd_ble_gatts_exchange_mtu_reply` on the server, and the client must initiate the exchange).
